### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,21 +12,21 @@ TH02_dev	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-ReadTemperature	        KEYWORD2
-ReadHumidity            KEYWORD2
+ReadTemperature	KEYWORD2
+ReadHumidity	KEYWORD2
  
 TH02_IIC_WriteCmd	KEYWORD2
 TH02_IIC_ReadReg	KEYWORD2
 TH02_IIC_ReadData	KEYWORD2
 TH02_IIC_ReadData2byte	KEYWORD2
 TH02_IIC_WriteReg	KEYWORD2
-isAvailable           KEYWORD2
-begin               KEYWORD2 
+isAvailable	KEYWORD2
+begin	KEYWORD2 
 #######################################
 # Instances (KEYWORD2)
 #######################################
-TH02 KEYWORD2
-TwoWire KEYWORD2
+TH02	KEYWORD2
+TwoWire	KEYWORD2
  
 
 #######################################


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords